### PR TITLE
Add a "start on oldest binlog" example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,12 @@ client.registerEventListener(new EventListener() {
         ...
     }
 });
+
+// start replication from oldest binlog
+// remove these lines to start from the current master binlog position
+client.setBinlogFilename("");
+client.setBinlogPosition(4);
+
 client.connect();
 ```
 


### PR DESCRIPTION
Extend example to show how to start replication from the oldest known binlog (empty filename + position 4).

It took me some time (+google +reading code) to find out how to do it. It might thus be useful for others, too.
