### PR TITLE
3 years of upstream bugfixes!

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/shyiko/mysql-binlog-connector-java/compare/0.2.2...HEAD)
 
+### Fixed
+ - BINARY/VARBINARY deserialization ([#56](https://github.com/shyiko/mysql-binlog-connector-java/issues/56)).  
+This is **BACKWARD-INCOMPATIBLE** change as CHAR/VARCHAR/BINARY/VARBINARY are now returned as `byte[]` (which you can obviously convert to String with `new String(byte[], Charset)`). 
+
 ## [0.2.2](https://github.com/shyiko/mysql-binlog-connector-java/compare/0.2.1...0.2.2) - 2015-07-10
 
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.21</version>
+            <version>5.1.34</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -237,7 +237,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.6.3.201306030806</version>
+                        <version>0.7.5.201505241946</version>
                         <configuration>
                             <destFile>${basedir}/target/coverage-reports/jacoco-unit.exec</destFile>
                             <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/AbstractRowsEventDataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/AbstractRowsEventDataDeserializer.java
@@ -32,19 +32,29 @@ import java.util.Map;
  *
  * Current {@link ColumnType} to java type mapping is following:
  * <pre>
- * Integer: {@link ColumnType#TINY}, {@link ColumnType#SHORT}, {@link ColumnType#LONG}, {@link ColumnType#INT24},
- * {@link ColumnType#YEAR}, {@link ColumnType#ENUM}, {@link ColumnType#SET},
- * Long: {@link ColumnType#LONGLONG},
- * Float: {@link ColumnType#FLOAT},
- * Double: {@link ColumnType#DOUBLE},
- * String: {@link ColumnType#VARCHAR}, {@link ColumnType#VAR_STRING}, {@link ColumnType#STRING},
- * java.util.BitSet: {@link ColumnType#BIT},
- * java.util.Date: {@link ColumnType#DATETIME}, {@link ColumnType#DATETIME_V2},
- * java.math.BigDecimal: {@link ColumnType#NEWDECIMAL},
- * java.sql.Timestamp: {@link ColumnType#TIMESTAMP}, {@link ColumnType#TIMESTAMP_V2},
- * java.sql.Date: {@link ColumnType#DATE},
- * java.sql.Time: {@link ColumnType#TIME}, {@link ColumnType#TIME_V2},
- * byte[]: {@link ColumnType#BLOB},
+ * {@link ColumnType#TINY}: Integer
+ * {@link ColumnType#SHORT}: Integer
+ * {@link ColumnType#LONG}: Integer
+ * {@link ColumnType#INT24}: Integer
+ * {@link ColumnType#YEAR}: Integer
+ * {@link ColumnType#ENUM}: Integer
+ * {@link ColumnType#SET}: Integer
+ * {@link ColumnType#LONGLONG}: Long
+ * {@link ColumnType#FLOAT}: Float
+ * {@link ColumnType#DOUBLE}: Double
+ * {@link ColumnType#BIT}: java.util.BitSet
+ * {@link ColumnType#DATETIME}: java.util.Date
+ * {@link ColumnType#DATETIME_V2}: java.util.Date
+ * {@link ColumnType#NEWDECIMAL}: java.math.BigDecimal
+ * {@link ColumnType#TIMESTAMP}: java.sql.Timestamp
+ * {@link ColumnType#TIMESTAMP_V2}: java.sql.Timestamp
+ * {@link ColumnType#DATE}: java.sql.Date
+ * {@link ColumnType#TIME}: java.sql.Time
+ * {@link ColumnType#TIME_V2}: java.sql.Time
+ * {@link ColumnType#VARCHAR}: byte[]
+ * {@link ColumnType#VAR_STRING}: byte[]
+ * {@link ColumnType#STRING}: byte[]
+ * {@link ColumnType#BLOB}: byte[]
  * </pre>
  *
  * At the moment {@link ColumnType#GEOMETRY} is unsupported.

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/AbstractRowsEventDataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/AbstractRowsEventDataDeserializer.java
@@ -143,12 +143,15 @@ public abstract class AbstractRowsEventDataDeserializer<T extends EventData> imp
             case YEAR:
                 return 1900 + inputStream.readInteger(1);
             case STRING:
+                // CHAR or BINARY:
+                // because there is no charset info (read: a way to distinguish between these two)
+                // we are returning byte[] instead of an actual String
                 int stringLength = length < 256 ? inputStream.readInteger(1) : inputStream.readInteger(2);
-                return inputStream.readString(stringLength);
-            case VARCHAR:
+                return inputStream.read(stringLength);
+            case VARCHAR: // or VARBINARY
             case VAR_STRING:
                 int varcharLength = meta < 256 ? inputStream.readInteger(1) : inputStream.readInteger(2);
-                return inputStream.readString(varcharLength);
+                return inputStream.read(varcharLength);
             case BLOB:
                 int blobLength = inputStream.readInteger(meta);
                 return inputStream.read(blobLength);

--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
@@ -39,6 +39,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import javax.xml.bind.DatatypeConverter;
 import java.io.Closeable;
 import java.io.EOFException;
 import java.io.IOException;
@@ -151,7 +152,7 @@ public class BinaryLogClientIntegrationTest {
             List<Serializable[]> writtenRows =
                 capturingEventListener.getEvents(WriteRowsEventData.class).get(0).getRows();
             assertEquals(writtenRows.size(), 1);
-            assertEquals(writtenRows.get(0), new Serializable[]{"SpongeBob"});
+            assertEquals(writtenRows.get(0), new Serializable[]{"SpongeBob".getBytes()});
             master.execute(new Callback<Statement>() {
                 @Override
                 public void execute(Statement statement) throws SQLException {
@@ -162,8 +163,8 @@ public class BinaryLogClientIntegrationTest {
             List<Map.Entry<Serializable[], Serializable[]>> updatedRows =
                 capturingEventListener.getEvents(UpdateRowsEventData.class).get(0).getRows();
             assertEquals(updatedRows.size(), 1);
-            assertEquals(updatedRows.get(0).getKey(), new Serializable[]{"SpongeBob"});
-            assertEquals(updatedRows.get(0).getValue(), new Serializable[]{"Patrick"});
+            assertEquals(updatedRows.get(0).getKey(), new Serializable[]{"SpongeBob".getBytes()});
+            assertEquals(updatedRows.get(0).getValue(), new Serializable[]{"Patrick".getBytes()});
             master.execute(new Callback<Statement>() {
                 @Override
                 public void execute(Statement statement) throws SQLException {
@@ -174,7 +175,7 @@ public class BinaryLogClientIntegrationTest {
             List<Serializable[]> deletedRows =
                 capturingEventListener.getEvents(DeleteRowsEventData.class).get(0).getRows();
             assertEquals(deletedRows.size(), 1);
-            assertEquals(deletedRows.get(0), new Serializable[]{"Patrick"});
+            assertEquals(deletedRows.get(0), new Serializable[]{"Patrick".getBytes()});
         } finally {
             client.unregisterEventListener(capturingEventListener);
         }
@@ -224,10 +225,12 @@ public class BinaryLogClientIntegrationTest {
             new java.sql.Time(generateTime(1970, 1, 1, 1, 2, 3, 0))});
         assertEquals(writeAndCaptureRow("year", "'69'"), new Serializable[]{2069});
         // string types
-        assertEquals(writeAndCaptureRow("char", "'q'"), new Serializable[]{"q"});
-        assertEquals(writeAndCaptureRow("varchar(255)", "'we'"), new Serializable[]{"we"});
-        assertEquals(writeAndCaptureRow("binary", "'r'"), new Serializable[]{"r"});
-        assertEquals(writeAndCaptureRow("varbinary(255)", "'ty'"), new Serializable[]{"ty"});
+        assertEquals(writeAndCaptureRow("char", "'q'"), new Serializable[]{"q".getBytes()});
+        assertEquals(writeAndCaptureRow("varchar(255)", "'we'"), new Serializable[]{"we".getBytes()});
+        assertEquals(writeAndCaptureRow("binary", "'r'"), new Serializable[]{"r".getBytes()});
+        assertEquals(writeAndCaptureRow("binary(16)", "unhex(md5(\"glob\"))"),
+            new Serializable[]{DatatypeConverter.parseHexBinary("8684147451a6cc3b92142c6f4b78e61c")});
+        assertEquals(writeAndCaptureRow("varbinary(255)", "'ty'"), new Serializable[]{"ty".getBytes()});
         assertEquals(writeAndCaptureRow("tinyblob", "'ui'"), new Serializable[]{"ui".getBytes()});
         assertEquals(writeAndCaptureRow("tinytext", "'op'"), new Serializable[]{"op".getBytes()});
         assertEquals(writeAndCaptureRow("blob", "'as'"), new Serializable[]{"as".getBytes()});


### PR DESCRIPTION
bump mysql connector to 5.1.34 (3 years of updates/fixes)
bump jacoco to 0.7.5.201505241946 (JDK 8 support, and ~2 years of updates/fixes)

tests seem to pass, hoping travis kicks in after I open this though
