### PR TITLE
ByteArrayInputStream peek may be wrong after EOF

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
@@ -171,7 +171,7 @@ public class ByteArrayInputStream extends InputStream {
     }
 
     public int peek() throws IOException {
-        if (peek == null) {
+        if (peek == null || peek == -1) {
             peek = readWithinBlockBoundaries();
         }
         return peek;
@@ -180,7 +180,7 @@ public class ByteArrayInputStream extends InputStream {
     @Override
     public int read() throws IOException {
         int result;
-        if (peek == null) {
+        if (peek == null || peek == -1) {
             result = readWithinBlockBoundaries();
         } else {
             result = peek;


### PR DESCRIPTION
When we eventually reach EOF on an ever growing binlog, nextEvent
cannot read a new event because peek is -1, but this peek is saved
from the previous event reaching EOF and may be out of sync with
the underlying InputStream.

This change makes peek() always check the underlying stream if
it had just EOF'd (peek == -1)