### PR TITLE
Changed the client so that GTIDs are updated before calling the event listeners (0.4.2)

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -731,9 +731,9 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                     continue;
                 }
                 if (isConnected()) {
+                    updateGtidSet(event);
                     notifyEventListeners(event);
                     updateClientBinlogFilenameAndPosition(event);
-                    updateGtidSet(event);
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
Previously, GTIDs were updated at the same time the binlog filename and position were updated: after the event listeners were called. However, this means that the GTID set was not yet updated when the event listeners were called, meaning that the event listeners would see the old GTID set if they asked for it.

With this change, the GTID set is updated before the event listeners are called, and the binlog filename and position (which reference the _next_ event) are updated after the event listeners are called. This ensures that the event listeners see the event's correct GTID set and binlog filename and position.

fixes #122 