### PR TITLE
Use available() for string length on ROWS_QUERY

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/RowsQueryEventDataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/RowsQueryEventDataDeserializer.java
@@ -27,7 +27,8 @@ public class RowsQueryEventDataDeserializer implements EventDataDeserializer<Row
     @Override
     public RowsQueryEventData deserialize(ByteArrayInputStream inputStream) throws IOException {
         RowsQueryEventData eventData = new RowsQueryEventData();
-        int len = inputStream.readInteger(1);
+        inputStream.skip(1);
+        int len = inputStream.available();
         eventData.setQuery(inputStream.readString(len));
         return eventData;
     }


### PR DESCRIPTION
Fix issue where ROWS_QUERY deserializer sometimes doesn't get the entire query string by relying on the data "length" byte.

I found that in some cases, readInteger would not give me the correct string length for a ROWS_QUERY event.