### PR TITLE
Don't verify identity for REQUIRED or PREFERRED

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -530,9 +530,12 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                 SSLRequestCommand sslRequestCommand = new SSLRequestCommand();
                 sslRequestCommand.setCollation(collation);
                 channel.write(sslRequestCommand, packetNumber++);
-                SSLSocketFactory sslSocketFactory = this.sslSocketFactory != null ? this.sslSocketFactory :
-                    sslMode == SSLMode.REQUIRED ? DEFAULT_REQUIRED_SSL_MODE_SOCKET_FACTORY :
-                        DEFAULT_VERIFY_CA_SSL_MODE_SOCKET_FACTORY;
+                SSLSocketFactory sslSocketFactory =
+                    this.sslSocketFactory != null ?
+                        this.sslSocketFactory :
+                        sslMode == SSLMode.REQUIRED || sslMode == SSLMode.PREFERRED ?
+                            DEFAULT_REQUIRED_SSL_MODE_SOCKET_FACTORY :
+                            DEFAULT_VERIFY_CA_SSL_MODE_SOCKET_FACTORY;
                 channel.upgradeToSSL(sslSocketFactory,
                     sslMode == SSLMode.VERIFY_IDENTITY ? new TLSHostnameVerifier() : null);
             }


### PR DESCRIPTION
Currently, SSL identity is verified for SSLMode.PREFERRED, VERIFY_CA, VERIFY_IDENTITY; not verified for SSLMode.REQUIRED.

This PR verifies SSL identity for SSLMode.VERIFY_CA, VERIFY_IDENTITY; not for SSLMode.REQUIRED or PREFERRED.

