### PR TITLE
NPE on mysql disconnect

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -741,6 +741,9 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                     event = eventDeserializer.nextEvent(packetLength == MAX_PACKET_LENGTH ?
                         new ByteArrayInputStream(readPacketSplitInChunks(inputStream, packetLength - 1)) :
                         inputStream);
+                    if (event == null) {
+                        throw new EOFException();
+                    }
                 } catch (Exception e) {
                     Throwable cause = e instanceof EventDataDeserializationException ? e.getCause() : e;
                     if (cause instanceof EOFException || cause instanceof SocketException) {


### PR DESCRIPTION
`eventDeserializer.nextEvent` can return `null` instead of `Event` if there is no more data to read. Later, this `null`-event is being passed to `updateGtidSet` and causes NPE. I think this is a race condition related to `connected` state.