### PR TITLE
Add new method putUUIDSet to GTIDSet

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/GtidSet.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/GtidSet.java
@@ -180,7 +180,7 @@ public class GtidSet {
         private String uuid;
         private List<Interval> intervals;
 
-        UUIDSet(String uuid, List<Interval> intervals) {
+        public UUIDSet(String uuid, List<Interval> intervals) {
             this.uuid = uuid;
             this.intervals = intervals;
             if (intervals.size() > 1) {
@@ -349,7 +349,7 @@ public class GtidSet {
         private long start;
         private long end;
 
-        Interval(long start, long end) {
+        public Interval(long start, long end) {
             this.start = start;
             this.end = end;
         }

--- a/src/main/java/com/github/shyiko/mysql/binlog/GtidSet.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/GtidSet.java
@@ -84,6 +84,16 @@ public class GtidSet {
     }
 
     /**
+     * Add or replace the UUIDSet
+     * @param uuidSet UUIDSet to be added
+     * @return the old {@link UUIDSet} for the server given in uuidSet param,
+     *         or {@code null} if there are no UUIDSet for the given server.
+     */
+    public UUIDSet putUUIDSet(UUIDSet uuidSet) {
+        return map.put(uuidSet.getUUID(), uuidSet);
+    }
+
+    /**
      * @param gtid GTID ("source_id:transaction_id")
      * @return whether or not gtid was added to the set (false if it was already there)
      */

--- a/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
@@ -154,4 +154,14 @@ public class GtidSetTest {
         assertEquals(gtidSet.toString(), UUID + ":1-199:1000-1033:1035-1036:1038-1039");
     }
 
+    @Test
+    public void testPutUUIDSet() {
+        GtidSet gtidSet = new GtidSet(UUID + ":1-191");
+        UUIDSet uuidSet = gtidSet.getUUIDSet(UUID);
+        GtidSet gtidSet2 = new GtidSet(UUID + ":1-190");
+        UUIDSet uuidSet2 = gtidSet2.getUUIDSet(UUID);
+        gtidSet.putUUIDSet(uuidSet2);
+        assertEquals(gtidSet, gtidSet2);
+    }
+
 }


### PR DESCRIPTION
Allow the client program add or replace the UUIDSet in GTIDSet

This might be useful when the client program want to adjust the intervals in GTIDSet/UUIDSet, e.g. when the client program don't have contiguous gtid ranges.