### PR TITLE
Fix connectLock loosing in terminateConnect's IOException

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -1135,9 +1135,12 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
 
     private void terminateConnect() throws IOException {
         do {
-            disconnectChannel();
+            try {
+                disconnectChannel();
+            } finally {
+                connectLock.unlock();
+            }
         } while (!tryLockInterruptibly(connectLock, 1000, TimeUnit.MILLISECONDS));
-        connectLock.unlock();
     }
 
     private static boolean tryLockInterruptibly(Lock lock, long time, TimeUnit unit) {


### PR DESCRIPTION
Method `terminateConnect` calls method `disconnectChannel` under `connectLock`. `disconnectChannel` may throw IOException, then lock will be loosen. This may cause a problem when keep-alive thread is enabled because it tries to call `terminateConnect` concurrently with binlog thread.