### PR TITLE
add DATE_AND_TIME_AS_STRING

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventDeserializer.java
@@ -184,6 +184,9 @@ public class EventDeserializer {
             deserializer.setDeserializeCharAndBinaryAsByteArray(
                 compatibilitySet.contains(CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY)
             );
+            deserializer.setDeserializeDateAndTimeAsString(
+                compatibilitySet.contains(CompatibilityMode.DATE_AND_TIME_AS_STRING)
+            );
         }
     }
 
@@ -288,7 +291,11 @@ public class EventDeserializer {
          *
          * <p>This option is going to be enabled by default starting from mysql-binlog-connector-java@1.0.0.
          */
-        CHAR_AND_BINARY_AS_BYTE_ARRAY
+        CHAR_AND_BINARY_AS_BYTE_ARRAY,
+        /**
+         * Return DATETIME/DATETIME_V2/TIMESTAMP/TIMESTAMP_V2/DATE/TIME/TIME_V2 values as String
+         */
+        DATE_AND_TIME_AS_STRING
     }
 
     /**


### PR DESCRIPTION
Add a new mode of EventDataDeserializer compatibility, 'DATE_AND_TIME_AS_STRING':
Date:'yyyy-mm-dd'
Time:'HH:mm:ss'
Timestamp/Datetime:'yyyy-mm-dd  HH:mm:ss'
Year:'yyyy'