### PR TITLE
Add integration tests to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,20 @@
+sudo: required
+
 language: java
-script: ./mvnw clean package -DskipTests=true
+
+services:
+  - docker
+
+env:
+  - DOCKER_COMPOSE_VERSION=1.22.0
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+script:
+  - docker-compose up -d
+  - docker-compose logs -f mysql-bootstrap
+  - ./mvnw clean verify

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,46 @@
+version: '3'
+
+services:
+  mysql-master:
+    image: "bitnami/mysql:5.7"
+    ports:
+      - '33061:3306'
+    environment:
+      - MYSQL_REPLICATION_MODE=master
+      - MYSQL_REPLICATION_USER=rsandbox
+      - MYSQL_REPLICATION_PASSWORD=rsandbox
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_USER=msandbox
+      - MYSQL_PASSWORD=msandbox
+      - MYSQL_DATABASE=msandbox
+
+  mysql-slave:
+    image: "bitnami/mysql:5.7"
+    ports:
+      - '33062:3306'
+    depends_on:
+      - mysql-master
+    environment:
+      - MYSQL_REPLICATION_MODE=slave
+      - MYSQL_REPLICATION_USER=rsandbox
+      - MYSQL_REPLICATION_PASSWORD=rsandbox
+      - MYSQL_MASTER_HOST=mysql-master
+      - MYSQL_MASTER_PORT_NUMBER=3306
+      - MYSQL_MASTER_ROOT_PASSWORD=root
+
+  mysql-bootstrap:
+    image: "bitnami/mysql:5.7"
+    depends_on:
+      - mysql-master
+      - mysql-slave
+    command: >
+      /bin/bash -c "
+      until mysql --host=mysql-master --port=3306 --user=root --password=root -e 'quit'; do
+        >&2 echo 'mysql-master is unavailable - sleeping'
+        sleep 1
+      done
+
+      >&2 echo 'mysql-master is up'
+
+      mysql --host=mysql-master --port=3306 --user=root --password=root -e \"GRANT ALL PRIVILEGES ON *.* TO 'msandbox'@'%' WITH GRANT OPTION;\"
+      "

--- a/pom.xml
+++ b/pom.xml
@@ -141,48 +141,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--
-                unfortunately net.ju-n.maven.plugins:vagrant-maven-plugin does not support vagrant 1.1+
-                at the moment, so I'm gonna use exec-maven-plugin instead
-            -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.1.1</version>
-                <executions>
-                    <execution>
-                        <id>start-vagrant-vm</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <workingDirectory>${vagrant.integration.box}</workingDirectory>
-                            <executable>${vagrant.bin}</executable>
-                            <arguments>
-                                <argument>up</argument>
-                            </arguments>
-                            <skip>${skipTests}</skip>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>destroy-vagrant-vm</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <workingDirectory>${vagrant.integration.box}</workingDirectory>
-                            <executable>${vagrant.bin}</executable>
-                            <arguments>
-                                <argument>destroy</argument>
-                                <argument>--force</argument>
-                            </arguments>
-                            <skip>${skipTests}</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
Currently there are two failing test cases that seem related to the Java version being run by Travis (running this with `oraclejdk8` vs `openjdk8` leads to different test failures). Unfortunately, I don't have sufficient knowledge of this library to fix them; however, hopefully this PR at least shows how to execute these tests in CI.

```
Results :
Failed tests: 
  BinaryLogClientIntegrationTest.testDeserializationOfDateAndTimeAsLong:402->writeAndCaptureRow:478 » IndexOutOfBounds
  JsonBinaryValueIntegrationTest.testScalarNegativeInt32:294->assertJSONMatchOriginal:396->writeAndCaptureJSON:423 » IndexOutOfBounds
Tests run: 79, Failures: 2, Errors: 0, Skipped: 0
```
