### PR TITLE
fix(ByteArrayOutputStream): call composed OutputStream#write

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayOutputStream.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayOutputStream.java
@@ -68,6 +68,11 @@ public class ByteArrayOutputStream extends OutputStream {
         outputStream.write(b);
     }
 
+    @Override
+    public void write(byte[] bytes) throws IOException {
+        outputStream.write(bytes);
+    }
+
     public byte[] toByteArray() {
         // todo: whole approach feels wrong
         if (outputStream instanceof java.io.ByteArrayOutputStream) {


### PR DESCRIPTION
In PacketChannel#write, when we wrote to PacketChannel.outputStream instead of PacketChannel.socket#getOutputStream, we use the default OutputStream#write(byte[]), which doesn't work with Azure. 

By overriding the OutputStream#write(byte[]) method in ByteArrayOutputStream, we use the write method provided PacketChannel.socket#getOutputStream, fixing the problem. 