### PR TITLE
fixes for non-strictly sequential behavior in JSON fields

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/json/JsonBinary.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/json/JsonBinary.java
@@ -189,6 +189,7 @@ public class JsonBinary {
 
     public JsonBinary(ByteArrayInputStream contents) {
         this.reader = contents;
+        this.reader.mark(Integer.MAX_VALUE);
     }
 
     public String getString() {
@@ -397,6 +398,8 @@ public class JsonBinary {
                 }
             } else {
                 // Parse the value ...
+                this.reader.reset();
+                this.reader.skip(entry.index + 1);
                 parse(entry.type, formatter);
             }
         }

--- a/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
@@ -218,4 +218,18 @@ public class ByteArrayInputStream extends InputStream {
         }
     }
 
+    @Override
+    public synchronized void mark(int readlimit) {
+        inputStream.mark(readlimit);
+    }
+
+    @Override
+    public boolean markSupported() {
+        return inputStream.markSupported();
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        inputStream.reset();
+    }
 }


### PR DESCRIPTION
as of MySQL 8.0.16, there are cases (see https://github.com/zendesk/maxwell/issues/1290) in which MySQL places JSON binary data at the offset specified in the header instead of just laying it out in order.  It leaves junk data in between string fields, presumably there's some deep buffer-copy-something going on under the good.

@shyiko I could write a test for this case but we'd have to bring up a 8.0.16 virtualbox or else it just won't repro....

