### PR TITLE
Add master server ID to BinaryLogClient.

### DIFF
--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
@@ -994,6 +994,7 @@ public class BinaryLogClientIntegrationTest {
 
     @Test
     public void testMySQL8TableMetadata() throws Exception {
+        master.execute("drop table if exists test_metameta");
         master.execute("create table test_metameta ( " +
                 "a date, b date, c date, d date, e date, f date, g date, " +
                 "h date, i date, j int)");

--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
@@ -1002,6 +1002,17 @@ public class BinaryLogClientIntegrationTest {
         eventListener.waitFor(WriteRowsEventData.class, 1, DEFAULT_TIMEOUT);
     }
 
+    @Test
+    public void testSetMasterServerId() throws Exception {
+        slave.query("SELECT @@server_id", new Callback<ResultSet>() {
+            @Override
+            public void execute(final ResultSet rs) throws SQLException {
+                rs.next();
+                assertEquals(client.getMasterServerId(), rs.getLong("@@server_id"));
+            }
+        });
+    }
+
     @AfterMethod
     public void afterEachTest() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
When the `BinaryLogClient` connects to a MySQL server, it's not
currently possible to identify to which server it has connected. When
connecting to a pool of replicas through a load balancer, for example, a
reconnect may mean the `BinaryLogClient` is connected to a different
MySQL server.

When using binary log file positions instead of GTIDs, this can be
critical: attempting to resume from the same binary log positions on a
different MySQL server may result in missed or duplicated events.
Similarly, not resuming from the same binary log positions when
reconnecting to the same server is wasteful and may result in longer
recovery/catch-up times.

This change adds the ability to get the equivalent of `MASTER_SERVER_ID`
from the `BinaryLogClient`. This can then be inspected within each of
the `LifecycleListener` events.

This pull request also includes a separate commit to fix an unrelated test.